### PR TITLE
Update nxos.py

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -25,6 +25,7 @@ NET_COMMON_ARGS = dict(
     password=dict(no_log=True),
     transport=dict(default='cli', choices=['cli', 'nxapi']),
     use_ssl=dict(default=False, type='bool'),
+    validate_certs=dict(default=True, type='bool'),
     provider=dict(type='dict')
 )
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

```
ansible 2.0.1.0
  config file = /home/bob/ansible-networking/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

Allow the option to set validate_certs to false to allow connection to devices using self-signed certs
##### Example output:

Before:

```
fatal: [10.127.49.32]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for 10.127.49.32:443. Make sure your managed systems have a valid CA certificate installed.  If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine.  You can use validate_certs=False if you do not need to confirm the server\\s identity but this is unsafe and not recommended Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
fatal: [10.127.49.31]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to validate the SSL certificate for 10.127.49.31:443. Make sure your managed systems have a valid CA certificate installed.  If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine.  You can use validate_certs=False if you do not need to confirm the server\\s identity but this is unsafe and not recommended Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
```

After:
validate_certs: no

```
fatal: [10.127.49.32]: FAILED! => {"changed": false, "failed": true, "msg": "HTTP Error 400: Bad Request", "status": 400, "url": "https://10.127.49.32:443/ins"}
fatal: [10.127.49.31]: FAILED! => {"changed": false, "failed": true, "msg": "HTTP Error 400: Bad Request", "status": 400, "url": "https://10.127.49.31:443/ins"}
```

Link to example playbook:
https://gist.github.com/RNanney/0662588ec59be7b379f1
